### PR TITLE
Give Token an owned string with the lexeme.

### DIFF
--- a/src/ast_printer.rs
+++ b/src/ast_printer.rs
@@ -26,12 +26,12 @@ impl AstPrinter {
     }
 }
 
-impl<'s> ExprVisitor<'s, String> for AstPrinter {
-    fn visit_binary(&mut self, lhs: &Expr<'s>, operator: &Token<'s>, rhs: &Expr<'s>) -> String {
-        self.parenthesize(operator.lexeme, &[lhs, rhs])
+impl ExprVisitor<String> for AstPrinter {
+    fn visit_binary(&mut self, lhs: &Expr, operator: &Token, rhs: &Expr) -> String {
+        self.parenthesize(&operator.lexeme, &[lhs, rhs])
     }
 
-    fn visit_grouping(&mut self, expression: &Expr<'s>) -> String {
+    fn visit_grouping(&mut self, expression: &Expr) -> String {
         self.parenthesize("group", &[expression])
     }
 
@@ -43,8 +43,8 @@ impl<'s> ExprVisitor<'s, String> for AstPrinter {
         }
     }
 
-    fn visit_unary(&mut self, operator: &Token<'s>, operand: &Expr<'s>) -> String {
-        self.parenthesize(operator.lexeme, &[operand])
+    fn visit_unary(&mut self, operator: &Token, operand: &Expr) -> String {
+        self.parenthesize(&operator.lexeme, &[operand])
     }
 }
 

--- a/src/bin/generate_ast.rs
+++ b/src/bin/generate_ast.rs
@@ -2,10 +2,10 @@ use std::{fs::File, io::Write, path::PathBuf, process::ExitCode};
 
 static EXPRESSION_GRAMMAR: &[&str] = &[
     // "Expr     : Binary | Grouping | Literal | Unary",
-    "Binary   : lhs: Expr<'s>, operator: Token<'s>, rhs: Expr<'s>",
-    "Grouping : expression: Expr<'s>",
+    "Binary   : lhs: Expr, operator: Token, rhs: Expr",
+    "Grouping : expression: Expr",
     "Literal  : value: Literal",
-    "Unary    : operator: Token<'s>, operand: Expr<'s>",
+    "Unary    : operator: Token, operand: Expr",
 ];
 
 struct Symbol {
@@ -79,7 +79,7 @@ fn main() -> ExitCode {
 }
 
 fn define_ast(out: &mut dyn Write, grammar: &[Rule]) -> Result<(), std::io::Error> {
-    writeln!(out, "pub enum Expr<'s> {{")?;
+    writeln!(out, "pub enum Expr {{")?;
 
     for rule in grammar {
         writeln!(out, "    {} {{", rule.head)?;
@@ -99,10 +99,10 @@ fn define_accepter(out: &mut dyn Write, grammar: &[Rule]) -> Result<(), std::io:
     // and it doesn't match the Rust Design Patterns description either.
     // Nevertheless, this seems like a useful way to go about it.
 
-    writeln!(out, "impl<'s> Expr<'s> {{")?;
+    writeln!(out, "impl Expr {{")?;
     writeln!(
         out,
-        "    pub fn accept<R>(&self, visitor: &mut dyn ExprVisitor<'s, R>) -> R {{"
+        "    pub fn accept<R>(&self, visitor: &mut dyn ExprVisitor<R>) -> R {{"
     )?;
     writeln!(out, "        match self {{")?;
 
@@ -131,7 +131,7 @@ fn define_accepter(out: &mut dyn Write, grammar: &[Rule]) -> Result<(), std::io:
 }
 
 fn define_visitor(out: &mut dyn Write, grammar: &[Rule]) -> Result<(), std::io::Error> {
-    writeln!(out, "pub trait ExprVisitor<'s, R> {{")?;
+    writeln!(out, "pub trait ExprVisitor<R> {{")?;
 
     for rule in grammar {
         write!(

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1,23 +1,23 @@
 use crate::token::{Literal, Token};
-pub enum Expr<'s> {
+pub enum Expr {
     Binary {
-        lhs: Box<Expr<'s>>,
-        operator: Box<Token<'s>>,
-        rhs: Box<Expr<'s>>,
+        lhs: Box<Expr>,
+        operator: Box<Token>,
+        rhs: Box<Expr>,
     },
     Grouping {
-        expression: Box<Expr<'s>>,
+        expression: Box<Expr>,
     },
     Literal {
         value: Box<Literal>,
     },
     Unary {
-        operator: Box<Token<'s>>,
-        operand: Box<Expr<'s>>,
+        operator: Box<Token>,
+        operand: Box<Expr>,
     },
 }
-impl<'s> Expr<'s> {
-    pub fn accept<R>(&self, visitor: &mut dyn ExprVisitor<'s, R>) -> R {
+impl Expr {
+    pub fn accept<R>(&self, visitor: &mut dyn ExprVisitor<R>) -> R {
         match self {
             Expr::Binary { lhs, operator, rhs } => visitor.visit_binary(lhs, operator, rhs),
             Expr::Grouping { expression } => visitor.visit_grouping(expression),
@@ -26,9 +26,9 @@ impl<'s> Expr<'s> {
         }
     }
 }
-pub trait ExprVisitor<'s, R> {
-    fn visit_binary(&mut self, lhs: &Expr<'s>, operator: &Token<'s>, rhs: &Expr<'s>) -> R;
-    fn visit_grouping(&mut self, expression: &Expr<'s>) -> R;
+pub trait ExprVisitor<R> {
+    fn visit_binary(&mut self, lhs: &Expr, operator: &Token, rhs: &Expr) -> R;
+    fn visit_grouping(&mut self, expression: &Expr) -> R;
     fn visit_literal(&mut self, value: &Literal) -> R;
-    fn visit_unary(&mut self, operator: &Token<'s>, operand: &Expr<'s>) -> R;
+    fn visit_unary(&mut self, operator: &Token, operand: &Expr) -> R;
 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -34,16 +34,16 @@ pub struct ScannerError {
     message: String,
 }
 
-enum ScanResult<'source> {
+enum ScanResult {
     Skip,
     Error(ScannerError),
-    Token(Token<'source>),
+    Token(Token),
 }
 
 pub struct Scanner<'source> {
     /// View of the source that remains to be scanned
     source: &'source str,
-    tokens: Vec<Token<'source>>,
+    tokens: Vec<Token>,
 
     /// Current character in the lexeme being scanned
     current: usize,
@@ -55,13 +55,13 @@ impl<'source> Scanner<'source> {
     pub fn new(source: &'source str) -> Self {
         Scanner {
             source,
-            tokens: Vec::<Token<'source>>::new(),
+            tokens: Vec::<Token>::new(),
             current: 0,
             line: 1,
         }
     }
 
-    pub fn scan_tokens(&mut self) -> Result<Vec<Token<'source>>, Vec<ScannerError>> {
+    pub fn scan_tokens(&mut self) -> Result<Vec<Token>, Vec<ScannerError>> {
         let mut errors = Vec::<ScannerError>::new();
 
         while !self.is_at_end() {
@@ -135,7 +135,7 @@ impl<'source> Scanner<'source> {
         Err(result)
     }
 
-    fn string(&mut self) -> Result<Token<'source>, ScannerError> {
+    fn string(&mut self) -> Result<Token, ScannerError> {
         let mut line = self.line;
 
         // TODO: this can probably be ... more concise
@@ -163,7 +163,7 @@ impl<'source> Scanner<'source> {
         Err(result)
     }
 
-    fn number(&mut self) -> Token<'source> {
+    fn number(&mut self) -> Token {
         while let Some(c) = self.peek() {
             if c.is_ascii_digit() {
                 self.advance();
@@ -194,7 +194,7 @@ impl<'source> Scanner<'source> {
         )
     }
 
-    fn identifier(&mut self) -> Token<'source> {
+    fn identifier(&mut self) -> Token {
         while let Some(c) = self.peek() {
             if c.is_alphanumeric() || c == '_' {
                 self.advance();
@@ -209,7 +209,7 @@ impl<'source> Scanner<'source> {
         }
     }
 
-    fn scan_token(&mut self) -> ScanResult<'source> {
+    fn scan_token(&mut self) -> ScanResult {
         use ScanResult::{Error, Skip, Token};
 
         match self.advance() {
@@ -270,11 +270,11 @@ impl<'source> Scanner<'source> {
         &self.source[..self.current]
     }
 
-    fn new_token(&self, token_type: TokenType) -> Token<'source> {
+    fn new_token(&self, token_type: TokenType) -> Token {
         Token::new(token_type, self.lexeme(), self.line)
     }
 
-    fn new_literal_token(&self, token_type: TokenType, literal: Literal) -> Token<'source> {
+    fn new_literal_token(&self, token_type: TokenType, literal: Literal) -> Token {
         Token::new_literal(token_type, self.lexeme(), literal, self.line)
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -62,39 +62,38 @@ impl From<&str> for Literal {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Token<'source> {
+pub struct Token {
     pub token_type: TokenType,
-    pub lexeme: &'source str,
+    // Fun Fact™: In a previous iteration, `lexeme` was a &str slice of the
+    // source text, but it turns out that's really annoying - everything
+    // contains tokens or references to them, including errors which outlive
+    // the source string.
+    pub lexeme: String,
     pub literal: Option<Literal>,
     pub line: usize,
 }
 
-impl<'source> Token<'source> {
-    pub fn new(token_type: TokenType, lexeme: &'source str, line: usize) -> Self {
+impl Token {
+    pub fn new(token_type: TokenType, lexeme: &str, line: usize) -> Self {
         Token {
             token_type,
-            lexeme,
+            lexeme: lexeme.into(),
             literal: None,
             line,
         }
     }
 
-    pub fn new_literal(
-        token_type: TokenType,
-        lexeme: &'source str,
-        literal: Literal,
-        line: usize,
-    ) -> Self {
+    pub fn new_literal(token_type: TokenType, lexeme: &str, literal: Literal, line: usize) -> Self {
         Token {
             token_type,
-            lexeme,
+            lexeme: lexeme.into(),
             literal: Some(literal),
             line,
         }
     }
 }
 
-impl<'source> Display for Token<'source> {
+impl Display for Token {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.literal {
             Some(literal) => write!(f, "{:?} {} {:?}", self.token_type, self.lexeme, literal),


### PR DESCRIPTION
Previously, Token held a `&str` slice of the source text, which is nice in theory but very annoying when it ends up bubbling up beyond the scope of the source text. I think we'll manage with regard to memory use.